### PR TITLE
Fixed typographical error, changed apparant to apparent in README.

### DIFF
--- a/README.html
+++ b/README.html
@@ -18,7 +18,7 @@
 <p>What if you could just do this:</p>
 <pre><code class="lang-html">&lt;div class=&quot;button-large-success&quot;&gt;Large Success Button&lt;/div&gt;
 </code></pre>
-<p>The benefits of using this HTML over conventional BEM syntax are self-apparant. However, you may be looking at that thinking of several reasons why it wouldn&#39;t work; what if I want to only use the &quot;button&quot; class on its own? What if I only want a large button, or only want a success button? Well, with Modular, all this is possible.</p>
+<p>The benefits of using this HTML over conventional BEM syntax are self-apparent. However, you may be looking at that thinking of several reasons why it wouldn&#39;t work; what if I want to only use the &quot;button&quot; class on its own? What if I only want a large button, or only want a success button? Well, with Modular, all this is possible.</p>
 <pre><code class="lang-scss">@include component(button) {
     // core button styles
     ...

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ What if you could just do this:
 <div class="button-large-success">Large Success Button</div>
 ```
 
-The benefits of using this HTML over conventional BEM syntax are self-apparant. However, you may be looking at that thinking of several reasons why it wouldn't work; what if I want to only use the "button" class on its own? What if I only want a large button, or only want a success button? Well, with Modular, all this is possible.
+The benefits of using this HTML over conventional BEM syntax are self-apparent. However, you may be looking at that thinking of several reasons why it wouldn't work; what if I want to only use the "button" class on its own? What if I only want a large button, or only want a success button? Well, with Modular, all this is possible.
 
 ```scss
 @include component(button) {


### PR DESCRIPTION
@esr360, I've corrected a typographical error in the documentation of the [Modular](https://github.com/esr360/Modular) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.